### PR TITLE
Raise on Stytch error responses

### DIFF
--- a/app/controllers/stytch_controller.rb
+++ b/app/controllers/stytch_controller.rb
@@ -1,4 +1,6 @@
 class StytchController < ApplicationController
+  class StytchError < StandardError; end
+
   def login; end
 
   def create
@@ -10,6 +12,10 @@ class StytchController < ApplicationController
       login_magic_link_url: authenticate_url,
       signup_magic_link_url: authenticate_url
     )
+    if resp['status_code'] != 200
+      Rails.logger.error resp
+      raise StytchError, "#{resp['error_type']}: #{resp['error_message']} (#{resp['error_url']})"
+    end
 
     # You might want to have different templates for new users and returning
     # users.  If you do, consider that this may allow an attacker to use the


### PR DESCRIPTION
If the `login_or_create` call fails for any reason, the form seems to succeed but the email is never sent.  In my case, I hadn't configured my magic link URLs.  With this change, the form submission will now log the error response and raise an exception.
