### PR TITLE
Update magic/redirect link url

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repo shows one way to integrate Stytch magic link logins into a Rails app.
 
 ## Add Magic Link URL
-Visit https://stytch.com/dashboard/magic-link-urls to add
+Visit https://stytch.com/dashboard/redirect-urls to add
 `http://localhost:3000/authenticate` as a valid sign-up and login URL.
 
 ## Development Setup


### PR DESCRIPTION
👋 I was just attempting to get the rails example app up and running and noticed that this URL has changed. I believe the old one still works, but this may help reduce confusion down the road.

_Side Note - I've so far been unable to get the example fully working due to this error:_
`StytchController::StytchError (invalid_login_magic_link_url: login_magic_link_url format is invalid. Common issues include using http instead of https, omitting https://, or having a trailing /. (https://stytch.com/docs/api/errors/400)):`
1. Is it possible to allowlist `http://` for the `test` environment or to provide additional instructions for working around this? Ideally new developers could avoid trying to spin up SSL to take this example for a spin.
2. It may be nice to pass back the actual invalid url as part of the error message, so the developer can immediately compare it to the common issues provided.

Thanks!